### PR TITLE
Deny react-p5 build script to unblock pnpm install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  react-p5: false


### PR DESCRIPTION
Close #717

The production deploy from `main` fails at dependency installation:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: react-p5@1.4.1
Error: Command "pnpm install" exited with 1
```

pnpm 11 turns unapproved dependency build scripts into a hard error instead of a warning, so `pnpm install` exits 1 and the build never starts. It slipped through the last PR because that build reused a cached `node_modules`, while `main` logged `Recreating /vercel/path0/node_modules` and re-ran the build-scripts phase.

The only affected script is `react-p5@1.4.1`'s `postinstall`: `opencollective-postinstall || exit 0`, a donation banner the package does not need in order to work. This denies it rather than approving it.

## Changes

New `pnpm-workspace.yaml`:

```yaml
allowBuilds:
  react-p5: false
```

## Verification

With pnpm 11.9.0 locally, the same version Vercel uses:

| Config | Result |
| --- | --- |
| no config | `ERR_PNPM_IGNORED_BUILDS`, exit 1 (reproduces the Vercel failure) |
| `pnpm.ignoredBuiltDependencies` in package.json | still fails |
| `ignoredBuiltDependencies` in pnpm-workspace.yaml | still fails |
| `allowBuilds: { react-p5: false }` | clean install, exit 0 |

The older `onlyBuiltDependencies` / `ignoredBuiltDependencies` keys are no longer read by pnpm 11; `allowBuilds` replaces them.

`pnpm install --frozen-lockfile` and `pnpm build` both pass on this branch (TypeScript check clean, 3 static pages generated). The lockfile is unchanged.